### PR TITLE
Potential fix for code scanning alert no. 2: Permissive CORS configuration

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -13,9 +13,22 @@ const __dirname = path.dirname(__filename);
 const PORT = process.env.PORT || 5000;
 // instantiate an express app
 const app = express();
+const allowedOrigins = (process.env.ALLOWED_ORIGINS || "")
+	.split(",")
+	.map((origin) => origin.trim())
+	.filter(Boolean);
 
 // cors
-app.use(cors({ origin: "*" }));
+app.use(
+	cors({
+		origin: (origin, callback) => {
+			// Allow non-browser or same-origin requests without Origin header
+			if (!origin) return callback(null, true);
+			if (allowedOrigins.includes(origin)) return callback(null, true);
+			return callback(new Error("Not allowed by CORS"));
+		},
+	})
+);
 app.use(express.static("public"));
 
 const transporter = nodemailer.createTransport({


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeadev/node-mailer/security/code-scanning/2](https://github.com/jorgeadev/node-mailer/security/code-scanning/2)

Use a restrictive CORS policy instead of `origin: "*"`. The best fix here (without changing app behavior more than necessary) is to define an allowlist from environment configuration and validate request origins against it in the CORS `origin` callback.

In `src/server.ts`, replace the current `app.use(cors({ origin: "*" }));` with:
- a parsed allowlist from `process.env.ALLOWED_ORIGINS` (comma-separated),
- a CORS origin function that:
  - allows requests with no `Origin` header (non-browser/server-to-server),
  - allows only origins present in the allowlist,
  - rejects everything else.

This keeps functionality for trusted frontends while removing broad cross-origin exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
