### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"dotenv": "17.4.1",
 		"express": "5.2.1",
 		"multiparty": "4.2.3",
-		"nodemailer": "8.0.5"
+		"nodemailer": "8.0.5",
+		"express-rate-limit": "^8.3.2"
 	},
 	"devDependencies": {
 		"@tailwindcss/cli": "4.2.2",

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import "dotenv/config";
 import nodemailer from "nodemailer";
 import multiparty from "multiparty";
+import rateLimit from "express-rate-limit";
 
 // ESM __dirname workaround
 const __filename = fileURLToPath(import.meta.url);
@@ -13,6 +14,13 @@ const __dirname = path.dirname(__filename);
 const PORT = process.env.PORT || 5000;
 // instantiate an express app
 const app = express();
+
+const indexRateLimiter = rateLimit({
+	windowMs: 15 * 60 * 1000, // 15 minutes
+	max: 100, // limit each IP to 100 requests per window
+	standardHeaders: true,
+	legacyHeaders: false,
+});
 
 // cors
 app.use(cors({ origin: "*" }));
@@ -84,7 +92,7 @@ app.post("/send", (req: Request, res: Response) => {
 });
 
 // index page (static HTML)
-app.get("/", (req: Request, res: Response) => {
+app.get("/", indexRateLimiter, (req: Request, res: Response) => {
 	res.sendFile(path.join(__dirname, "../public", "index.html"));
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/jorgeadev/node-mailer/security/code-scanning/1](https://github.com/jorgeadev/node-mailer/security/code-scanning/1)

The best fix is to add a standard rate-limiting middleware (`express-rate-limit`) and apply it to routes performing potentially expensive work. In this file, the clearest minimal change is:

1. Import `express-rate-limit`.
2. Define a limiter (window + max requests).
3. Attach it to the flagged `GET /` route (and optionally `/send`, but to keep behavior minimally changed and focused on the alert, apply to `/`).

This preserves existing functionality while adding request throttling protection.  
In `src/server.ts`, add the import near other imports, add limiter configuration after app initialization, and update the `app.get("/")` signature to include the limiter as middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
